### PR TITLE
design: Authorization Page 디자인

### DIFF
--- a/app/(afterAuth)/home/page.tsx
+++ b/app/(afterAuth)/home/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>Home</div>;
+};
+
+export default Page;

--- a/app/(afterAuth)/layout.tsx
+++ b/app/(afterAuth)/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+type AfterAuthLayoutProps = {
+  children: ReactNode;
+};
+
+function AfterAuthLayout({ children }: AfterAuthLayoutProps) {
+  return <div>{children}</div>;
+}
+
+export default AfterAuthLayout;

--- a/app/(beforeAuth)/@modal/(.)accounts/login/page.tsx
+++ b/app/(beforeAuth)/@modal/(.)accounts/login/page.tsx
@@ -1,0 +1,14 @@
+import ModalContainer from "@/app/(beforeAuth)/_components/Modal/ModalContainer";
+import BasicInput from "@/app/(beforeAuth)/_components/Modal/BasicInput";
+
+export default function Login() {
+  return (
+    <>
+      난 가로채기지롱
+      <ModalContainer text='로그인하세요.' authType='login' heightType='loginHeight'>
+        <BasicInput type='id' text='아이디' />
+        <BasicInput type='password' text='비밀번호' />
+      </ModalContainer>
+    </>
+  );
+}

--- a/app/(beforeAuth)/@modal/(.)accounts/signup/page.tsx
+++ b/app/(beforeAuth)/@modal/(.)accounts/signup/page.tsx
@@ -1,0 +1,34 @@
+import ModalContainer from "@/app/(beforeAuth)/_components/Modal/ModalContainer";
+import BasicInput from "@/app/(beforeAuth)/_components/Modal/BasicInput";
+
+export default function Signup() {
+  return (
+    <>
+      난 가로채기지롱
+      <ModalContainer
+        text='계정을 생성하세요.'
+        authType='signup'
+        heightType='signupHeight'
+      >
+        <BasicInput type='id' text='아이디' />
+        <BasicInput type='name' text='닉네임' />
+        <BasicInput type='password' text='비밀번호' />
+
+        <div id='inner-div' className='flex flex-col h-14 relative my-3'>
+          <label
+            htmlFor='image'
+            className='absolute top-0 w-full h-14 inline-block border border-1 border-ivory rounded text-sm px-2 pt-2 text-gray-700'
+          >
+            프로필
+          </label>
+          <input
+            id='image'
+            type='file'
+            accept='image/*'
+            className='w-full border-none text-base mt-4 px-2 pt-3 pb-2 outline-none'
+          />
+        </div>
+      </ModalContainer>
+    </>
+  );
+}

--- a/app/(beforeAuth)/@modal/default.tsx
+++ b/app/(beforeAuth)/@modal/default.tsx
@@ -1,0 +1,5 @@
+const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/app/(beforeAuth)/_components/Modal/BasicInput.tsx
+++ b/app/(beforeAuth)/_components/Modal/BasicInput.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from "react";
+
+type BasicInputProps = {
+  type: "name" | "id" | "password";
+  text: "아이디" | "닉네임" | "비밀번호";
+  children?: ReactNode;
+};
+
+const BasicInput = ({ type, text, children }: BasicInputProps) => {
+  // Input type이 image와 같이 특별한 Element로 children을 받는 경우
+  if (children) {
+    <div id='inner-div' className='flex flex-col h-14 relative my-3'>
+      <label
+        htmlFor={type}
+        className='absolute top-0 w-full h-14 inline-block border border-1 border-ivory rounded text-sm px-2 pt-2 text-gray-700'
+      >
+        {text}
+      </label>
+      {children}
+    </div>;
+  }
+
+  // Modal에서 기본 Style
+  return (
+    <div id='inner-div' className='flex flex-col h-14 relative my-3'>
+      <label
+        htmlFor={type}
+        className='absolute top-0 w-full h-14 inline-block border border-1 border-ivory rounded text-sm px-2 pt-2 text-gray-700'
+      >
+        {text}
+      </label>
+      <input
+        id={type}
+        type={type === "password" ? "password" : "text"}
+        className='w-full border-none text-base mt-4 px-2 pt-3 pb-2 outline-none'
+      />
+    </div>
+  );
+};
+
+export default BasicInput;

--- a/app/(beforeAuth)/_components/Modal/Footer.tsx
+++ b/app/(beforeAuth)/_components/Modal/Footer.tsx
@@ -1,0 +1,18 @@
+type FooterProps = {
+  type: "login" | "signup";
+};
+
+const Footer = ({ type }: FooterProps) => {
+  return (
+    <div id='modal-footer' className='px-20 py-6'>
+      <button
+        disabled
+        className='w-full h-12 rounded-3xl bg-blackBtn text-white text-lg'
+      >
+        {type === "signup" ? "가입하기" : "로그인하기"}
+      </button>
+    </div>
+  );
+};
+
+export default Footer;

--- a/app/(beforeAuth)/_components/Modal/Header.tsx
+++ b/app/(beforeAuth)/_components/Modal/Header.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type ModalHeaderProps = {
+  text: string;
+};
+
+const Header = ({ text }: ModalHeaderProps) => {
+  const router = useRouter();
+  const onClickCloseModal = () => {
+    router.back();
+  };
+
+  return (
+    <div id='modal-header' className='pt-9 pb-5 px-20 text-3xl font-bold'>
+      <button
+        className='w-9 h-9 border-none rounded-2xl cursor-pointer bg-white left-4 top-4 flex justify-center items-center absolute hover:bg-blackBtn-modalBg'
+        onClick={onClickCloseModal}
+      >
+        <svg
+          width={24}
+          viewBox='0 0 24 24'
+          aria-hidden='true'
+          className='r-18jsvk2 r-4qtqp9 r-yyyyoo r-z80fyv r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03'
+        >
+          <g>
+            <path d='M10.59 12L4.54 5.96l1.42-1.42L12 10.59l6.04-6.05 1.42 1.42L13.41 12l6.05 6.04-1.42 1.42L12 13.41l-6.04 6.05-1.42-1.42L10.59 12z'></path>
+          </g>
+        </svg>
+      </button>
+      <div>{text}</div>
+    </div>
+  );
+};
+
+export default Header;

--- a/app/(beforeAuth)/_components/Modal/ModalContainer.tsx
+++ b/app/(beforeAuth)/_components/Modal/ModalContainer.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from "react";
+import Header from "./Header";
+import Footer from "./Footer";
+
+type ModalContainerProps = {
+  children: ReactNode;
+  text: string;
+  authType: "login" | "signup";
+};
+
+const ModalContainer = ({ children, text, authType }: ModalContainerProps) => {
+  return (
+    <section
+      id='model-background'
+      className='w-screen h-full flex justify-center absolute inset-0 bg-black/[.3]'
+    >
+      <div
+        id='modal'
+        className='relative flex flex-col max-w-[80%] min-w-[600px] h-[550px] top-[5%] bg-white rounded-2xl'
+      >
+        <Header text={text} />
+
+        <form className='flex flex-col flex-1 border'>
+          <div id='modal-body' className='flex-1 px-20'>
+            {children}
+          </div>
+
+          <Footer type={authType} />
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default ModalContainer;

--- a/app/(beforeAuth)/_components/Modal/ModalContainer.tsx
+++ b/app/(beforeAuth)/_components/Modal/ModalContainer.tsx
@@ -6,9 +6,20 @@ type ModalContainerProps = {
   children: ReactNode;
   text: string;
   authType: "login" | "signup";
+  heightType: "loginHeight" | "signupHeight";
 };
 
-const ModalContainer = ({ children, text, authType }: ModalContainerProps) => {
+const ModalContainer = ({
+  children,
+  text,
+  authType,
+  heightType,
+}: ModalContainerProps) => {
+  const heights = {
+    loginHeight: "h-[450px]",
+    signupHeight: "h-[550px]",
+  };
+
   return (
     <section
       id='model-background'
@@ -16,11 +27,11 @@ const ModalContainer = ({ children, text, authType }: ModalContainerProps) => {
     >
       <div
         id='modal'
-        className='relative flex flex-col max-w-[80%] min-w-[600px] h-[550px] top-[5%] bg-white rounded-2xl'
+        className={`relative flex flex-col max-w-[80%] min-w-[600px] top-[5%] bg-white rounded-2xl ${heights[heightType]}`}
       >
         <Header text={text} />
 
-        <form className='flex flex-col flex-1 border'>
+        <form className='flex flex-col flex-1'>
           <div id='modal-body' className='flex-1 px-20'>
             {children}
           </div>

--- a/app/(beforeAuth)/accounts/login/page.tsx
+++ b/app/(beforeAuth)/accounts/login/page.tsx
@@ -1,0 +1,13 @@
+import ModalContainer from "@/app/(beforeAuth)/_components/Modal/ModalContainer";
+import BasicInput from "@/app/(beforeAuth)/_components/Modal/BasicInput";
+
+function Login() {
+  return (
+    <ModalContainer text='로그인하세요.' authType='login' heightType='loginHeight'>
+      <BasicInput type='id' text='아이디' />
+      <BasicInput type='password' text='비밀번호' />
+    </ModalContainer>
+  );
+}
+
+export default Login;

--- a/app/(beforeAuth)/accounts/signup/page.tsx
+++ b/app/(beforeAuth)/accounts/signup/page.tsx
@@ -1,0 +1,29 @@
+import BasicInput from "../../_components/Modal/BasicInput";
+import ModalContainer from "../../_components/Modal/ModalContainer";
+
+function Page() {
+  return (
+    <ModalContainer text='계정을 생성하세요.' authType='signup'>
+      <BasicInput type='id' text='아이디' />
+      <BasicInput type='name' text='닉네임' />
+      <BasicInput type='password' text='비밀번호' />
+
+      <div id='inner-div' className='flex flex-col h-14 relative my-3'>
+        <label
+          htmlFor='image'
+          className='absolute top-0 w-full h-14 inline-block border border-1 border-ivory rounded text-sm px-2 pt-2 text-gray-700'
+        >
+          프로필
+        </label>
+        <input
+          id='image'
+          type='file'
+          accept='image/*'
+          className='w-full border-none text-base mt-4 px-2 pt-3 pb-2 outline-none'
+        />
+      </div>
+    </ModalContainer>
+  );
+}
+
+export default Page;

--- a/app/(beforeAuth)/accounts/signup/page.tsx
+++ b/app/(beforeAuth)/accounts/signup/page.tsx
@@ -1,9 +1,13 @@
-import BasicInput from "../../_components/Modal/BasicInput";
-import ModalContainer from "../../_components/Modal/ModalContainer";
+import ModalContainer from "@/app/(beforeAuth)/_components/Modal/ModalContainer";
+import BasicInput from "@/app/(beforeAuth)/_components/Modal/BasicInput";
 
-function Page() {
+function Signup() {
   return (
-    <ModalContainer text='계정을 생성하세요.' authType='signup'>
+    <ModalContainer
+      text='계정을 생성하세요.'
+      authType='signup'
+      heightType='signupHeight'
+    >
       <BasicInput type='id' text='아이디' />
       <BasicInput type='name' text='닉네임' />
       <BasicInput type='password' text='비밀번호' />
@@ -26,4 +30,4 @@ function Page() {
   );
 }
 
-export default Page;
+export default Signup;

--- a/app/(beforeAuth)/layout.tsx
+++ b/app/(beforeAuth)/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+type BeforeAutoLayoutProps = {
+  children: ReactNode;
+};
+
+function BeforeAutoLayout({ children }: BeforeAutoLayoutProps) {
+  return <div>{children}</div>;
+}
+
+export default BeforeAutoLayout;

--- a/app/(beforeAuth)/layout.tsx
+++ b/app/(beforeAuth)/layout.tsx
@@ -1,11 +1,17 @@
 import { ReactNode } from "react";
 
-type BeforeAutoLayoutProps = {
+type BeforeAuthLayoutProps = {
   children: ReactNode;
+  modal: ReactNode;
 };
 
-function BeforeAutoLayout({ children }: BeforeAutoLayoutProps) {
-  return <div>{children}</div>;
+function BeforeAuthLayout({ children, modal }: BeforeAuthLayoutProps) {
+  return (
+    <div>
+      {children}
+      {modal}
+    </div>
+  );
 }
 
-export default BeforeAutoLayout;
+export default BeforeAuthLayout;

--- a/app/(beforeAuth)/not-fount.tsx
+++ b/app/(beforeAuth)/not-fount.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div>
+      <div>이 페이지는 존재하지 않습니다. 다른 페이지를 검색해 보세요.</div>
+      <Link href='/search'>검색</Link>
+    </div>
+  );
+}

--- a/app/(beforeAuth)/page.tsx
+++ b/app/(beforeAuth)/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import EMO_LOGO from "../public/EMO_Icon.png";
+import EMO_LOGO from "../../public/EMO_Icon.png";
 
 const commonLinkStyle =
   "flex justify-center items-center w-[300px] h-10 rounded-[20px] text-base";
@@ -28,7 +28,7 @@ export default function Home() {
           이미 EMO에 가입하셨나요?
         </h3>
         <Link
-          href='/account/login'
+          href='/accounts/login'
           className={`${commonLinkStyle} text-blue border border-1 border-ivory hover:bg-ivory-hover`}
         >
           로그인

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { PluginAPI } from "tailwindcss/types/config";
 
 const config: Config = {
   content: [
@@ -21,6 +22,11 @@ const config: Config = {
         orange: {
           DEFAULT: "rgb(251, 169, 63)",
           hover: "rgb(245, 160, 55)",
+        },
+        blackBtn: {
+          DEFAULT: "rgb(15,20,25)",
+          modalBg: "rgba(15,20,25, 0.1)",
+          hover: "rgba(15,20,25, 0.7)",
         },
       },
     },


### PR DESCRIPTION
## Linked Issues
- Resolved: #3 

## 구현 요구 사항

- EMO 사이트 Authorization(Login/Signup) 페이지를 디자인합니다.
    - Modal로 Authorization 페이지를 디자인합니다.
    - Root Page 위에 Modal을 보여줍니다.
    - 새로고침하면 Root Page가 아닌 fallback Page([default.js](https://nextjs.org/docs/app/api-reference/file-conventions/default))로 이동합니다.
- EMO 사이트의 첫 화면은 간단한 사이트 소개와 로그인 또는 회원가입을 진행할 수 있습니다.

## 구현 이미지

- *Root Page 위에 Modal을 보여줍니다.*
![Auth Page](https://github.com/user-attachments/assets/6678b2f8-bfcb-4aa7-97ae-7a9105e0350d)

- *새로고침하면 Root Page가 아닌 fallback Page([default.js](https://nextjs.org/docs/app/api-reference/file-conventions/default))로 이동합니다.*
![Refresh Auth page](https://github.com/user-attachments/assets/0f829812-b399-48e1-a57e-d7fd4bece566)

</br>
</br>

**작업 브랜치: `design/auth-page`**